### PR TITLE
Add Angular component for PDF template creation

### DIFF
--- a/angular/src/app/template-generator/template-generator.component.html
+++ b/angular/src/app/template-generator/template-generator.component.html
@@ -1,0 +1,177 @@
+<div class="template-generator" [formGroup]="form">
+  <h2>Template PDF</h2>
+
+  <section>
+    <h3>Metadati</h3>
+    <label>
+      Versione
+      <input formControlName="versione" placeholder="Versione" />
+    </label>
+  </section>
+
+  <section formGroupName="impostazioniPagina">
+    <h3>Impostazioni pagina</h3>
+
+    <div class="section-grid">
+      <div>
+        <h4>Margini</h4>
+        <div formGroupName="margini" class="grid">
+          <label>Sinistra <input formControlName="sx" type="number" /></label>
+          <label>Destra <input formControlName="dx" type="number" /></label>
+          <label>Alto <input formControlName="alto" type="number" /></label>
+          <label>Basso <input formControlName="basso" type="number" /></label>
+        </div>
+      </div>
+
+      <div>
+        <h4>Tipografia</h4>
+        <label>Interlinea <input formControlName="interlinea" type="number" step="0.01" /></label>
+        <label>Stacco riga <input formControlName="staccoriga" type="number" /></label>
+        <label>Rientro <input formControlName="rientro" type="number" /></label>
+      </div>
+
+      <div>
+        <h4>Box testo</h4>
+        <div formGroupName="box" class="grid">
+          <label>Background <input formControlName="background" type="color" /></label>
+          <label>Raggio <input formControlName="raggio" type="number" step="0.1" /></label>
+          <label>Padding <input formControlName="padding" type="number" step="0.1" /></label>
+          <label>Spessore linea <input formControlName="lineWidth" type="number" step="0.01" /></label>
+          <label>Colore linea <input formControlName="lineColor" type="color" /></label>
+        </div>
+      </div>
+    </div>
+
+    <div class="fonts">
+      <h4>Fonts</h4>
+      <div formArrayName="fonts">
+        <div *ngFor="let font of fonts.controls; let i = index" [formGroupName]="i" class="font-row">
+          <label>ID <input formControlName="id" /></label>
+          <label>Nome <input formControlName="nome" /></label>
+          <label>Dimensione <input formControlName="dimensione" type="number" /></label>
+          <label>Colore <input formControlName="colore" type="color" /></label>
+          <label>Stile <input formControlName="style" /></label>
+          <label>Percorso installazione <input formControlName="installPath" /></label>
+          <button type="button" (click)="removeFont(i)" *ngIf="fonts.length > 1">Rimuovi</button>
+        </div>
+      </div>
+      <button type="button" (click)="addFont()">Aggiungi font</button>
+    </div>
+  </section>
+
+  <section>
+    <h3>Contenuti</h3>
+    <div class="content-actions">
+      <label>Aggiungi elemento</label>
+      <div class="buttons">
+        <button type="button" (click)="addContent('testo')">Testo</button>
+        <button type="button" (click)="addContent('testoBox')">Box di testo</button>
+        <button type="button" (click)="addContent('saltoRiga')">Salto riga</button>
+        <button type="button" (click)="addContent('tabella')">Tabella</button>
+        <button type="button" (click)="addContent('punti')">Elenco puntato</button>
+        <button type="button" (click)="addContent('immagine')">Immagine</button>
+      </div>
+    </div>
+
+    <div formArrayName="contenuti" class="content-list">
+      <article *ngFor="let content of contenuti.controls; let i = index" [formGroupName]="i">
+        <header>
+          <span class="badge">{{ content.value.tipo | uppercase }}</span>
+          <button type="button" (click)="removeContent(i)">Rimuovi</button>
+        </header>
+
+        <ng-container [ngSwitch]="content.value.tipo">
+          <div *ngSwitchCase="'testo'" class="field">
+            <label>Testo</label>
+            <textarea formControlName="testo" rows="4"></textarea>
+          </div>
+
+          <div *ngSwitchCase="'testoBox'" class="field" formArrayName="testoBox">
+            <div *ngFor="let row of (content.get('testoBox') as FormArray).controls; let j = index" class="row-with-action">
+              <textarea [formControlName]="j" rows="2"></textarea>
+              <button type="button" (click)="removeTestoBoxRow(i, j)" *ngIf="(content.get('testoBox') as FormArray).length > 1">
+                Rimuovi riga
+              </button>
+            </div>
+            <button type="button" (click)="addTestoBoxRow(i)">Aggiungi riga</button>
+          </div>
+
+          <div *ngSwitchCase="'saltoRiga'" class="field">
+            <label>Numero righe</label>
+            <input formControlName="saltoRiga" type="number" min="1" />
+          </div>
+
+          <div *ngSwitchCase="'tabella'" class="field">
+            <label>Identificativo tabella</label>
+            <input formControlName="tabella" placeholder="Es. TABLE1" />
+          </div>
+
+          <div *ngSwitchCase="'punti'" class="field" formArrayName="punti">
+            <div *ngFor="let point of (content.get('punti') as FormArray).controls; let j = index" [formGroupName]="j" class="bullet">
+              <label>Titolo</label>
+              <input formControlName="titolo" />
+
+              <div formArrayName="sottopunti" class="subpoints">
+                <div
+                  *ngFor="let subPoint of (point.get('sottopunti') as FormArray).controls; let k = index"
+                  [formGroupName]="k"
+                  class="subpoint"
+                >
+                  <label>Titolo</label>
+                  <input formControlName="titolo" />
+
+                  <div formArrayName="contenuto" class="subpoint-content">
+                    <div *ngFor="let row of (subPoint.get('contenuto') as FormArray).controls; let r = index" class="row-with-action">
+                      <input [formControlName]="r" />
+                      <button type="button" (click)="removeSubPointContentRow(i, j, k, r)" *ngIf="(subPoint.get('contenuto') as FormArray).length > 1">
+                        Rimuovi riga
+                      </button>
+                    </div>
+                    <button type="button" (click)="addSubPointContentRow(i, j, k)">Aggiungi riga</button>
+                  </div>
+
+                  <button type="button" (click)="removeSubPoint(i, j, k)" *ngIf="(point.get('sottopunti') as FormArray).length > 1">
+                    Rimuovi sottoparagrafo
+                  </button>
+                </div>
+                <button type="button" (click)="addSubPoint(i, j)">Aggiungi sottoparagrafo</button>
+              </div>
+
+              <button type="button" (click)="removeBulletPoint(i, j)" *ngIf="(content.get('punti') as FormArray).length > 1">
+                Rimuovi sezione
+              </button>
+            </div>
+            <button type="button" (click)="addBulletPoint(i)">Aggiungi sezione</button>
+          </div>
+
+          <div *ngSwitchCase="'immagine'" class="field" formGroupName="immagine">
+            <label>Percorso</label>
+            <input formControlName="path" />
+
+            <div class="grid" formGroupName="posizione">
+              <label>X <input formControlName="x" type="number" /></label>
+              <label>Y <input formControlName="y" type="number" /></label>
+            </div>
+
+            <div class="grid" formGroupName="dimensioni">
+              <label>Larghezza <input formControlName="width" type="number" /></label>
+              <label>Altezza <input formControlName="height" type="number" /></label>
+            </div>
+
+            <label>Coefficiente dimensioni <input formControlName="coeffDim" type="number" step="0.001" /></label>
+          </div>
+        </ng-container>
+      </article>
+    </div>
+  </section>
+
+  <section class="actions">
+    <button type="button" (click)="loadExample()">Carica esempio</button>
+    <button type="button" (click)="downloadTemplate()" [disabled]="form.invalid">Scarica JSON</button>
+  </section>
+
+  <section>
+    <h3 class="preview-title">Anteprima JSON</h3>
+    <pre>{{ getTemplateJson() }}</pre>
+  </section>
+</div>

--- a/angular/src/app/template-generator/template-generator.component.scss
+++ b/angular/src/app/template-generator/template-generator.component.scss
@@ -1,0 +1,231 @@
+.template-generator {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  padding: 1.5rem;
+  background: #f5f7fb;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
+  font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  color: #0f172a;
+
+  h2 {
+    margin: 0;
+    font-size: 1.75rem;
+    font-weight: 600;
+  }
+
+  h3 {
+    margin-bottom: 0.75rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #1d4ed8;
+  }
+
+  section {
+    background: #ffffff;
+    border-radius: 10px;
+    padding: 1.25rem;
+    box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.875rem;
+    color: #1e293b;
+  }
+
+  input,
+  textarea,
+  button {
+    font: inherit;
+  }
+
+  input,
+  textarea {
+    padding: 0.5rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid #cbd5f5;
+    background-color: #f8fafc;
+    color: inherit;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+    &:focus {
+      border-color: #2563eb;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+      outline: none;
+    }
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  button {
+    align-self: flex-start;
+    padding: 0.45rem 0.9rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(135deg, #2563eb, #4338ca);
+    color: #fff;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+
+    &:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 10px 18px rgba(79, 70, 229, 0.2);
+    }
+
+    &:active {
+      transform: translateY(0);
+      box-shadow: none;
+    }
+
+    &:disabled {
+      background: #94a3b8;
+      cursor: not-allowed;
+      box-shadow: none;
+    }
+  }
+
+  .section-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .fonts {
+    margin-top: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    .font-row {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 0.75rem;
+      padding: 1rem;
+      border-radius: 8px;
+      background: #f1f5f9;
+      box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.25);
+    }
+  }
+
+  .content-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 1rem;
+
+    label {
+      font-weight: 600;
+      color: #1e3a8a;
+    }
+
+    .buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+
+      button {
+        background: linear-gradient(135deg, #0ea5e9, #2563eb);
+      }
+    }
+  }
+
+  .content-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    article {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      padding: 1rem;
+      border-radius: 10px;
+      background: #f8fafc;
+      box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.25);
+
+      header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .badge {
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        background: rgba(59, 130, 246, 0.1);
+        color: #1d4ed8;
+        font-size: 0.75rem;
+        letter-spacing: 0.05em;
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .row-with-action {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 0.5rem;
+        align-items: center;
+      }
+
+      .bullet {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 0.75rem;
+        border-radius: 8px;
+        background: rgba(59, 130, 246, 0.05);
+      }
+
+      .subpoints {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .subpoint {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 0.75rem;
+        border-radius: 8px;
+        background: rgba(59, 130, 246, 0.08);
+      }
+
+      .subpoint-content {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+    }
+  }
+
+  .actions {
+    display: flex;
+    gap: 1rem;
+  }
+
+  pre {
+    padding: 1rem;
+    border-radius: 12px;
+    background: #0f172a;
+    color: #e2e8f0;
+    max-height: 400px;
+    overflow: auto;
+  }
+}

--- a/angular/src/app/template-generator/template-generator.component.ts
+++ b/angular/src/app/template-generator/template-generator.component.ts
@@ -1,0 +1,664 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+interface TemplateFont {
+  id: string;
+  nome: string;
+  dimensione: number;
+  colore: string;
+  style: string;
+  installPath?: string;
+}
+
+interface TemplateMargins {
+  sx: number;
+  dx: number;
+  alto: number;
+  basso: number;
+}
+
+interface TemplateBox {
+  background: string;
+  raggio: number;
+  padding: number;
+  lineWidth: number;
+  lineColor: string;
+}
+
+interface TemplateContentBase {
+  tipo: 'testo' | 'testoBox' | 'saltoRiga' | 'tabella' | 'punti' | 'immagine';
+}
+
+interface TemplateTextContent extends TemplateContentBase {
+  tipo: 'testo';
+  testo: string;
+}
+
+interface TemplateTextBoxContent extends TemplateContentBase {
+  tipo: 'testoBox';
+  testoBox: string[];
+}
+
+interface TemplateLineBreakContent extends TemplateContentBase {
+  tipo: 'saltoRiga';
+  saltoRiga: number;
+}
+
+interface TemplateTableContent extends TemplateContentBase {
+  tipo: 'tabella';
+  tabella: string;
+}
+
+interface TemplateBulletContent extends TemplateContentBase {
+  tipo: 'punti';
+  punti: Array<{
+    titolo: string;
+    sottopunti: Array<{
+      titolo: string;
+      contenuto: string[];
+    }>;
+  }>;
+}
+
+interface TemplateImageContent extends TemplateContentBase {
+  tipo: 'immagine';
+  immagine: {
+    path: string;
+    posizione: [number, number];
+    dimensioni: [number, number];
+    coeffDim?: number;
+  };
+}
+
+type TemplateContent =
+  | TemplateTextContent
+  | TemplateTextBoxContent
+  | TemplateLineBreakContent
+  | TemplateTableContent
+  | TemplateBulletContent
+  | TemplateImageContent;
+
+interface TemplateConfig {
+  versione: string;
+  impostazioniPagina: {
+    fonts: TemplateFont[];
+    margini: TemplateMargins;
+    interlinea: number;
+    staccoriga: number;
+    rientro: number;
+    box: TemplateBox;
+  };
+  contenuti: TemplateContent[];
+}
+
+@Component({
+  selector: 'app-template-generator',
+  templateUrl: './template-generator.component.html',
+  styleUrls: ['./template-generator.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TemplateGeneratorComponent {
+  readonly form: FormGroup;
+
+  constructor(private readonly fb: FormBuilder) {
+    this.form = this.fb.group({
+      versione: ['0.1.1', Validators.required],
+      impostazioniPagina: this.fb.group({
+        fonts: this.fb.array([this.createFontGroup()]),
+        margini: this.fb.group({
+          sx: [10, Validators.required],
+          dx: [19, Validators.required],
+          alto: [10, Validators.required],
+          basso: [10, Validators.required],
+        }),
+        interlinea: [1.08, Validators.required],
+        staccoriga: [5, Validators.required],
+        rientro: [3, Validators.required],
+        box: this.fb.group({
+          background: ['#faffc7'],
+          raggio: [2],
+          padding: [2],
+          lineWidth: [0.12],
+          lineColor: ['#cc1269'],
+        }),
+      }),
+      contenuti: this.fb.array([this.createTextContentGroup()]),
+    });
+  }
+
+  get fonts(): FormArray<FormGroup> {
+    return this.form.get('impostazioniPagina.fonts') as FormArray<FormGroup>;
+  }
+
+  get contenuti(): FormArray<FormGroup> {
+    return this.form.get('contenuti') as FormArray<FormGroup>;
+  }
+
+  addFont(): void {
+    this.fonts.push(this.createFontGroup());
+  }
+
+  removeFont(index: number): void {
+    this.fonts.removeAt(index);
+  }
+
+  addContent(type: TemplateContent['tipo']): void {
+    switch (type) {
+      case 'testo':
+        this.contenuti.push(this.createTextContentGroup());
+        break;
+      case 'testoBox':
+        this.contenuti.push(this.createTextBoxContentGroup());
+        break;
+      case 'saltoRiga':
+        this.contenuti.push(this.createLineBreakGroup());
+        break;
+      case 'tabella':
+        this.contenuti.push(this.createTableGroup());
+        break;
+      case 'punti':
+        this.contenuti.push(this.createBulletGroup());
+        break;
+      case 'immagine':
+        this.contenuti.push(this.createImageGroup());
+        break;
+    }
+  }
+
+  removeContent(index: number): void {
+    this.contenuti.removeAt(index);
+  }
+
+  addTestoBoxRow(contentIndex: number): void {
+    const rows = this.contenuti.at(contentIndex).get('testoBox') as FormArray;
+    rows.push(this.fb.control('', Validators.required));
+  }
+
+  removeTestoBoxRow(contentIndex: number, rowIndex: number): void {
+    const rows = this.contenuti.at(contentIndex).get('testoBox') as FormArray;
+    rows.removeAt(rowIndex);
+  }
+
+  addBulletPoint(contentIndex: number): void {
+    const bulletArray = this.contenuti.at(contentIndex).get('punti') as FormArray<FormGroup>;
+    bulletArray.push(this.createBulletPointGroup());
+  }
+
+  removeBulletPoint(contentIndex: number, bulletIndex: number): void {
+    const bulletArray = this.contenuti.at(contentIndex).get('punti') as FormArray<FormGroup>;
+    bulletArray.removeAt(bulletIndex);
+  }
+
+  addSubPoint(contentIndex: number, bulletIndex: number): void {
+    const bulletArray = this.contenuti.at(contentIndex).get('punti') as FormArray<FormGroup>;
+    const subPoints = bulletArray.at(bulletIndex).get('sottopunti') as FormArray<FormGroup>;
+    subPoints.push(this.createSubPointGroup());
+  }
+
+  removeSubPoint(contentIndex: number, bulletIndex: number, subPointIndex: number): void {
+    const bulletArray = this.contenuti.at(contentIndex).get('punti') as FormArray<FormGroup>;
+    const subPoints = bulletArray.at(bulletIndex).get('sottopunti') as FormArray<FormGroup>;
+    subPoints.removeAt(subPointIndex);
+  }
+
+  addSubPointContentRow(
+    contentIndex: number,
+    bulletIndex: number,
+    subPointIndex: number
+  ): void {
+    const bulletArray = this.contenuti.at(contentIndex).get('punti') as FormArray<FormGroup>;
+    const subPoints = bulletArray.at(bulletIndex).get('sottopunti') as FormArray<FormGroup>;
+    const rows = subPoints.at(subPointIndex).get('contenuto') as FormArray;
+    rows.push(this.fb.control('', Validators.required));
+  }
+
+  removeSubPointContentRow(
+    contentIndex: number,
+    bulletIndex: number,
+    subPointIndex: number,
+    rowIndex: number
+  ): void {
+    const bulletArray = this.contenuti.at(contentIndex).get('punti') as FormArray<FormGroup>;
+    const subPoints = bulletArray.at(bulletIndex).get('sottopunti') as FormArray<FormGroup>;
+    const rows = subPoints.at(subPointIndex).get('contenuto') as FormArray;
+    rows.removeAt(rowIndex);
+  }
+
+  getTemplateJson(pretty = true): string {
+    const value = this.form.getRawValue();
+    return JSON.stringify(this.mapFormToTemplate(value), null, pretty ? 2 : undefined);
+  }
+
+  downloadTemplate(): void {
+    const json = this.getTemplateJson();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'template.json';
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  loadExample(): void {
+    const example = this.getExampleTemplate();
+    this.form.reset();
+
+    while (this.fonts.length) {
+      this.fonts.removeAt(0);
+    }
+
+    example.impostazioniPagina.fonts.forEach((font) => {
+      this.fonts.push(
+        this.fb.group({
+          id: [font.id, Validators.required],
+          nome: [font.nome, Validators.required],
+          dimensione: [font.dimensione, [Validators.required, Validators.min(1)]],
+          colore: [font.colore, Validators.required],
+          style: [font.style, Validators.required],
+          installPath: [font.installPath ?? ''],
+        })
+      );
+    });
+
+    while (this.contenuti.length) {
+      this.contenuti.removeAt(0);
+    }
+
+    example.contenuti.forEach((content) => {
+      switch (content.tipo) {
+        case 'testo':
+          this.contenuti.push(
+            this.fb.group({
+              tipo: ['testo'],
+              testo: [content.testo, Validators.required],
+            })
+          );
+          break;
+        case 'testoBox':
+          this.contenuti.push(
+            this.fb.group({
+              tipo: ['testoBox'],
+              testoBox: this.fb.array(content.testoBox.map((row) => this.fb.control(row, Validators.required))),
+            })
+          );
+          break;
+        case 'saltoRiga':
+          this.contenuti.push(
+            this.fb.group({
+              tipo: ['saltoRiga'],
+              saltoRiga: [content.saltoRiga, [Validators.required, Validators.min(1)]],
+            })
+          );
+          break;
+        case 'tabella':
+          this.contenuti.push(
+            this.fb.group({
+              tipo: ['tabella'],
+              tabella: [content.tabella, Validators.required],
+            })
+          );
+          break;
+        case 'punti':
+          this.contenuti.push(
+            this.fb.group({
+              tipo: ['punti'],
+              punti: this.fb.array(
+                content.punti.map((point) =>
+                  this.fb.group({
+                    titolo: [point.titolo, Validators.required],
+                    sottopunti: this.fb.array(
+                      point.sottopunti.map((sub) =>
+                        this.fb.group({
+                          titolo: [sub.titolo, Validators.required],
+                          contenuto: this.fb.array(sub.contenuto.map((row) => this.fb.control(row, Validators.required))),
+                        })
+                      )
+                    ),
+                  })
+                )
+              ),
+            })
+          );
+          break;
+        case 'immagine':
+          this.contenuti.push(
+            this.fb.group({
+              tipo: ['immagine'],
+              immagine: this.fb.group({
+                path: [content.immagine.path, Validators.required],
+                posizione: this.fb.group({
+                  x: [content.immagine.posizione[0], Validators.required],
+                  y: [content.immagine.posizione[1], Validators.required],
+                }),
+                dimensioni: this.fb.group({
+                  width: [content.immagine.dimensioni[0], Validators.required],
+                  height: [content.immagine.dimensioni[1], Validators.required],
+                }),
+                coeffDim: [content.immagine.coeffDim ?? null],
+              }),
+            })
+          );
+          break;
+      }
+    });
+
+    this.form.patchValue({
+      versione: example.versione,
+      impostazioniPagina: {
+        margini: example.impostazioniPagina.margini,
+        interlinea: example.impostazioniPagina.interlinea,
+        staccoriga: example.impostazioniPagina.staccoriga,
+        rientro: example.impostazioniPagina.rientro,
+        box: example.impostazioniPagina.box,
+      },
+    });
+  }
+
+  private createFontGroup(): FormGroup {
+    return this.fb.group({
+      id: ['', Validators.required],
+      nome: ['', Validators.required],
+      dimensione: [8, [Validators.required, Validators.min(1)]],
+      colore: ['#000000', Validators.required],
+      style: ['normal', Validators.required],
+      installPath: [''],
+    });
+  }
+
+  private createTextContentGroup(): FormGroup {
+    return this.fb.group({
+      tipo: ['testo'],
+      testo: ['', Validators.required],
+    });
+  }
+
+  private createTextBoxContentGroup(): FormGroup {
+    return this.fb.group({
+      tipo: ['testoBox'],
+      testoBox: this.fb.array([this.fb.control('', Validators.required)]),
+    });
+  }
+
+  private createLineBreakGroup(): FormGroup {
+    return this.fb.group({
+      tipo: ['saltoRiga'],
+      saltoRiga: [1, [Validators.required, Validators.min(1)]],
+    });
+  }
+
+  private createTableGroup(): FormGroup {
+    return this.fb.group({
+      tipo: ['tabella'],
+      tabella: ['', Validators.required],
+    });
+  }
+
+  private createBulletGroup(): FormGroup {
+    return this.fb.group({
+      tipo: ['punti'],
+      punti: this.fb.array([this.createBulletPointGroup()]),
+    });
+  }
+
+  private createBulletPointGroup(): FormGroup {
+    return this.fb.group({
+      titolo: ['', Validators.required],
+      sottopunti: this.fb.array([this.createSubPointGroup()]),
+    });
+  }
+
+  private createSubPointGroup(): FormGroup {
+    return this.fb.group({
+      titolo: ['', Validators.required],
+      contenuto: this.fb.array([this.fb.control('', Validators.required)]),
+    });
+  }
+
+  private createImageGroup(): FormGroup {
+    return this.fb.group({
+      tipo: ['immagine'],
+      immagine: this.fb.group({
+        path: ['', Validators.required],
+        posizione: this.fb.group({
+          x: [0, Validators.required],
+          y: [0, Validators.required],
+        }),
+        dimensioni: this.fb.group({
+          width: [40, Validators.required],
+          height: [20, Validators.required],
+        }),
+        coeffDim: [null],
+      }),
+    });
+  }
+
+  private mapFormToTemplate(formValue: any): TemplateConfig {
+    const fonts: TemplateFont[] = formValue.impostazioniPagina.fonts.map((font: any) => ({
+      id: font.id,
+      nome: font.nome,
+      dimensione: Number(font.dimensione),
+      colore: font.colore,
+      style: font.style,
+      ...(font.installPath ? { installPath: font.installPath } : {}),
+    }));
+
+    const contenuti: TemplateContent[] = formValue.contenuti.map((content: any) => {
+      switch (content.tipo) {
+        case 'testo':
+          return {
+            tipo: 'testo',
+            testo: content.testo,
+          } satisfies TemplateTextContent;
+        case 'testoBox':
+          return {
+            tipo: 'testoBox',
+            testoBox: content.testoBox,
+          } satisfies TemplateTextBoxContent;
+        case 'saltoRiga':
+          return {
+            tipo: 'saltoRiga',
+            saltoRiga: Number(content.saltoRiga),
+          } satisfies TemplateLineBreakContent;
+        case 'tabella':
+          return {
+            tipo: 'tabella',
+            tabella: content.tabella,
+          } satisfies TemplateTableContent;
+        case 'punti':
+          return {
+            tipo: 'punti',
+            punti: content.punti.map((point: any) => ({
+              titolo: point.titolo,
+              sottopunti: point.sottopunti.map((sub: any) => ({
+                titolo: sub.titolo,
+                contenuto: sub.contenuto,
+              })),
+            })),
+          } satisfies TemplateBulletContent;
+        case 'immagine':
+          return {
+            tipo: 'immagine',
+            immagine: {
+              path: content.immagine.path,
+              posizione: [Number(content.immagine.posizione.x), Number(content.immagine.posizione.y)],
+              dimensioni: [Number(content.immagine.dimensioni.width), Number(content.immagine.dimensioni.height)],
+              ...(content.immagine.coeffDim ? { coeffDim: Number(content.immagine.coeffDim) } : {}),
+            },
+          } satisfies TemplateImageContent;
+        default:
+          return content;
+      }
+    });
+
+    return {
+      versione: formValue.versione,
+      impostazioniPagina: {
+        fonts,
+        margini: {
+          sx: Number(formValue.impostazioniPagina.margini.sx),
+          dx: Number(formValue.impostazioniPagina.margini.dx),
+          alto: Number(formValue.impostazioniPagina.margini.alto),
+          basso: Number(formValue.impostazioniPagina.margini.basso),
+        },
+        interlinea: Number(formValue.impostazioniPagina.interlinea),
+        staccoriga: Number(formValue.impostazioniPagina.staccoriga),
+        rientro: Number(formValue.impostazioniPagina.rientro),
+        box: {
+          background: formValue.impostazioniPagina.box.background,
+          raggio: Number(formValue.impostazioniPagina.box.raggio),
+          padding: Number(formValue.impostazioniPagina.box.padding),
+          lineWidth: Number(formValue.impostazioniPagina.box.lineWidth),
+          lineColor: formValue.impostazioniPagina.box.lineColor,
+        },
+      },
+      contenuti,
+    } satisfies TemplateConfig;
+  }
+
+  private getExampleTemplate(): TemplateConfig {
+    return {
+      versione: '0.1.1',
+      impostazioniPagina: {
+        fonts: [
+          {
+            id: 'default',
+            nome: 'Montserrat',
+            dimensione: 8,
+            colore: '#000000',
+            style: 'bold, normal',
+            installPath: './Montserrat-Bold.ttf, ./Montserrat-Regular.ttf',
+          },
+          {
+            id: 'helvetica_10',
+            nome: 'helvetica',
+            dimensione: 10,
+            colore: '#000000',
+            style: 'normal',
+          },
+          {
+            id: 'testiPiccoli',
+            nome: 'courier',
+            dimensione: 6,
+            colore: '#000000',
+            style: 'italic',
+          },
+        ],
+        margini: { sx: 10, dx: 19, alto: 10, basso: 10 },
+        interlinea: 1.08,
+        staccoriga: 5,
+        rientro: 3,
+        box: {
+          background: '#faffc7',
+          raggio: 2,
+          padding: 2,
+          lineWidth: 0.12,
+          lineColor: '#cc1269',
+        },
+      },
+      contenuti: [
+        {
+          tipo: 'testoBox',
+          testoBox: [
+            'Contratto di servizio tra **pincoPallino Joe srl** e $cliente:denominazione$',
+            'Altro testo su una nuova riga per vedere dove arriva il cursore',
+            'Magari proviamo a scendere ulteriormente',
+          ],
+        },
+        {
+          tipo: 'immagine',
+          immagine: {
+            path: './logo.png',
+            posizione: [0, 0],
+            dimensioni: [40, 20],
+            coeffDim: 0.042,
+          },
+        },
+        {
+          tipo: 'testo',
+          testo: 'Questo è un testo di prova, potrebbe essere una intestazione con il **nome azienda**',
+        },
+        {
+          tipo: 'saltoRiga',
+          saltoRiga: 1,
+        },
+        {
+          tipo: 'testo',
+          testo: 'Contratto di servizio tra pincoPallino Joe srl e $cliente:denominazione$ in data $data$',
+        },
+        {
+          tipo: 'testo',
+          testo:
+            '<|fontId: default|>Il presente contratto (di seguito, "Contratto") regola i **termini** e le **condizioni** tra $fornitore:denominazione$, codice fiscale $fornitore:codiceFiscale$, con sede in $fornitore:indirizzoCompleto$, e $cliente:denominazione$, **codice fiscale** $cliente:codiceFiscale$, con sede in $cliente:indirizzoCompleto$, per la fornitura e gestione di kit di biancheria da lavanderie industriali.',
+        },
+        {
+          tipo: 'testo',
+          testo:
+            '^Omnis illo molestiae ut et amet **blanditiis** amet. Ea voluptas est nostrum saepe corrupti. Incidunt nobis quos voluptatem laboriosam excepturi sed. Deserunt exercitationem praesentium quasi. Ab blanditiis vero sit eveniet. Accusamus quae explicabo rerum rem corrupti placeat similique voluptatem. Non assumenda at voluptas deleniti ipsum numquam accusantium. Laudantium eum ut possimus ullam perferendis nemo. Facere distinctio earum quia. Unde rerum qui dolorum. Repellat esse veniam voluptatum dolores placeat et. Autem et labore provident non. Nihil dolore exercitationem vel hic dolorem voluptatem. Rerum quae natus quia consectetur eaque natus veritatis consequatur. Corporis magnam suscipit nihil autem natus. Quia libero et hic ipsam praesentium omnis aut esse.^',
+        },
+        {
+          tipo: 'testo',
+          testo: '<|fontId: helvetica_10|>^Box della **denominazione** del cliente $cliente:denominazione$^',
+        },
+        {
+          tipo: 'tabella',
+          tabella: 'TABLE1',
+        },
+        {
+          tipo: 'punti',
+          punti: [
+            {
+              titolo: '1. OGGETTO DEL CONTRATTO',
+              sottopunti: [
+                {
+                  titolo: '1.1. Servizio fornito da pincoPallino Joe srl',
+                  contenuto: [
+                    'pincoPallino Joe si impegna a:',
+                    '• Lanciare ',
+                    '• Schivare ',
+                    '• Piegarsi ',
+                    '• Abbassarsi ',
+                    '• Schivare ',
+                  ],
+                },
+                {
+                  titolo: '**1.3. Ordini**',
+                  contenuto: [
+                    'Gli **ordini** possono essere caricati:',
+                    '• Manualmente tramite lo store e-commerce pincoPallino Joe,',
+                    '• Gli ordini devono rispettare i check-out',
+                  ],
+                },
+                {
+                  titolo: '2.2. Il pagamento deve avvenire al momento dell\'ordine tramite:',
+                  contenuto: ['• Carta di credito', '• SEPA (bonifico bancario)', '• SDD'],
+                },
+                {
+                  titolo: '3.3. Consegne mancanti o ritardate',
+                  contenuto: [
+                    'In caso di mancata consegna per cause imputabili al Cliente, la consegna sarà riprogrammata con addebito:',
+                    '• Del costo della consegna “saltata”.',
+                    '• Del costo della nuova consegna.',
+                  ],
+                },
+                {
+                  titolo: '7.1. Obblighi del Cliente',
+                  contenuto: ['• Giocare a dodgeball'],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          tipo: 'immagine',
+          immagine: {
+            path: './logo.png',
+            posizione: [0, 0],
+            dimensioni: [40, 30],
+            coeffDim: 0.042,
+          },
+        },
+      ],
+    } satisfies TemplateConfig;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
+        "@angular/core": "^20.3.2",
+        "@angular/forms": "^20.3.2",
         "jspdf": "^3.0.0",
         "jspdf-autotable": "^5.0.2",
         "pdf-lib": "^1.17.1"
@@ -18,6 +20,107 @@
         "standard-version": "^9.5.0",
         "typescript": "^5.8.2"
       }
+    },
+    "node_modules/@angular/common": {
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.2.tgz",
+      "integrity": "sha512-5V9AzLhCA1dNhF+mvihmdHoZHbEhIb1jNYRA1/JMheR+G7NR8Mznu6RmWaKSWZ4AJeSJN8rizWN2wpVPWTKjSQ==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "20.3.2",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/common/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
+    },
+    "node_modules/@angular/core": {
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.2.tgz",
+      "integrity": "sha512-88uPgs5LjtnywnQaZE2ShBb1wa8IuD6jWs4nc4feo32QdBc55tjebTBFJSHbi3mUVAp0eS4wI6ITo0YIb01H4g==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "20.3.2",
+        "rxjs": "^6.5.3 || ^7.4.0",
+        "zone.js": "~0.15.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/compiler": {
+          "optional": true
+        },
+        "zone.js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/core/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/@angular/forms": {
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.2.tgz",
+      "integrity": "sha512-ECIbtwc7n9fPbiZXZVaoZpSiOksgcNbZ27oUN9BT7EmoXRzBw6yDL2UX6Ig7pEKhQGyBkKB+TMerRwTDVkkCWg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.3.2",
+        "@angular/core": "20.3.2",
+        "@angular/platform-browser": "20.3.2",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/forms/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/@angular/platform-browser": {
+      "version": "20.3.2",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.2.tgz",
+      "integrity": "sha512-d9XcT2UuWZCc0UOtkCcPEnMcOFKNczahamT/Izg3H9jLS3IcT6l0ry23d/Xf0DRwhLYQdOZiG7l8HMZ1sWPMOg==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "20.3.2",
+        "@angular/common": "20.3.2",
+        "@angular/core": "20.3.2"
+      },
+      "peerDependenciesMeta": {
+        "@angular/animations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/platform-browser/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
@@ -1920,6 +2023,21 @@
       "engines": {
         "node": ">= 0.8.15"
       }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   "license": "ISC",
   "description": "Contract generation",
   "dependencies": {
+    "@angular/core": "^20.3.2",
+    "@angular/forms": "^20.3.2",
     "jspdf": "^3.0.0",
     "jspdf-autotable": "^5.0.2",
     "pdf-lib": "^1.17.1"


### PR DESCRIPTION
## Summary
- add a TemplateGeneratorComponent that models the contract template schema with reactive forms and export helpers
- provide an HTML template to edit page settings, fonts, dynamic contents, and preview/download the JSON
- style the component layout for better readability of nested template sections

## Testing
- not run (Angular workspace not available in this repository)

------
https://chatgpt.com/codex/tasks/task_b_68dbfffb5b3483308f2db977ab6d83ca