### PR TITLE
Add endpoint to generate documents

### DIFF
--- a/backend/template/dto/generate-document.dto.ts
+++ b/backend/template/dto/generate-document.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DocumentParams } from '../../../interfaces/content';
+import { DocumentConfig } from '../../../interfaces/doc';
+
+export class GenerateDocumentDto {
+  @ApiProperty({ description: 'Parameters used to populate the document content.', type: () => Object })
+  params!: DocumentParams;
+
+  @ApiPropertyOptional({ description: 'Filesystem path of the template configuration to load.' })
+  configPath?: string;
+
+  @ApiPropertyOptional({ description: 'Template configuration to use instead of loading from disk.', type: () => Object })
+  config?: DocumentConfig;
+}
+
+export class GenerateDocumentResponse {
+  @ApiProperty({ description: 'Base64-encoded PDF document generated from the template.' })
+  document!: string;
+
+  @ApiProperty({ description: 'Path on disk where the generated PDF has been saved.' })
+  filePath!: string;
+}

--- a/backend/template/template.controller.ts
+++ b/backend/template/template.controller.ts
@@ -9,6 +9,7 @@ import {
 import { TemplateService } from './template.service';
 import { CreateTemplateDto, CreateTemplateResponse } from './dto/create-template.dto';
 import { UpdateTemplateDto, UpdateTemplateResponse } from './dto/update-template.dto';
+import { GenerateDocumentDto, GenerateDocumentResponse } from './dto/generate-document.dto';
 
 @ApiTags('templates')
 @Controller('templates')
@@ -37,5 +38,13 @@ export class TemplateController {
   @ApiOkResponse({ type: UpdateTemplateResponse })
   updateTemplate(@Body() body: UpdateTemplateDto) {
     return this.templateService.updateTemplate(body);
+  }
+
+  @Post('generate')
+  @ApiOperation({ summary: 'Generate a document using the provided template configuration.' })
+  @ApiBody({ type: GenerateDocumentDto })
+  @ApiOkResponse({ type: GenerateDocumentResponse })
+  generateDocument(@Body() body: GenerateDocumentDto) {
+    return this.templateService.generateDocument(body);
   }
 }

--- a/backend/template/template.service.ts
+++ b/backend/template/template.service.ts
@@ -3,6 +3,8 @@ import { TemplateGenerator } from '../../services/TemplateGenerator';
 import { CreateTemplateDto, CreateTemplateResponse } from './dto/create-template.dto';
 import { UpdateTemplateDto, UpdateTemplateResponse } from './dto/update-template.dto';
 import { DocumentConfig } from '../../interfaces/doc';
+import { GenerateDocumentDto, GenerateDocumentResponse } from './dto/generate-document.dto';
+import { DocumentGenerator } from '../../ContractGenerator';
 
 @Injectable()
 export class TemplateService {
@@ -57,5 +59,35 @@ export class TemplateService {
     }
 
     return { template };
+  }
+
+  async generateDocument(dto: GenerateDocumentDto): Promise<GenerateDocumentResponse> {
+    if (!dto.params) {
+      throw new BadRequestException('params is required to generate a document.');
+    }
+
+    if (!dto.config && !dto.configPath) {
+      throw new BadRequestException('Either config or configPath must be provided to generate a document.');
+    }
+
+    const generator = new DocumentGenerator(dto.configPath);
+
+    if (dto.config) {
+      generator.setConfig(dto.config);
+    }
+
+    try {
+      const document = await generator.generateDocument(dto.params);
+      if (!document) {
+        throw new Error('Document generation failed.');
+      }
+
+      return {
+        document,
+        filePath: dto.params.nomeFile,
+      };
+    } catch (error) {
+      throw new BadRequestException(`Unable to generate document: ${error instanceof Error ? error.message : error}`);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add DTOs describing the document generation payload and response
- expose a /templates/generate endpoint that delegates to DocumentGenerator

## Testing
- npm run build *(fails: missing NestJS packages in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dd26382ffc8330b0723c46f71bbcf9