### PR TITLE
Fix document generation service configuration handling

### DIFF
--- a/backend/generate/dto/generate-document.dto.ts
+++ b/backend/generate/dto/generate-document.dto.ts
@@ -12,7 +12,7 @@ export class GenerateDocumentDto {
   //#endregion
   
   //#region config
-  @ApiPropertyOptional({description: 'External json for configuration'})
+  @ApiPropertyOptional({ description: 'External json for configuration', type: () => Object })
   config?: DocumentConfig;
   
   //#region Client-Supplier

--- a/backend/generate/dto/generate-document.dto.ts
+++ b/backend/generate/dto/generate-document.dto.ts
@@ -1,6 +1,7 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiHideProperty, ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { DocumentConfig } from '../../../interfaces/doc';
 
+//#region GenerateDocumentDto
 export class GenerateDocumentDto {
   
   //#region fileName
@@ -12,9 +13,12 @@ export class GenerateDocumentDto {
   //#endregion
   
   //#region config
-  @ApiPropertyOptional({ description: 'External json for configuration', type: () => Object })
+  /** allow to pass a json to use for the template of the document */
+  @ApiHideProperty()
   config?: DocumentConfig;
-  
+  //#endregion
+
+
   //#region Client-Supplier
   @ApiPropertyOptional({ 
     description: 'Business name for the client', 
@@ -96,7 +100,9 @@ export class GenerateDocumentDto {
   tableBody?: any[][];
   //#endregion
 }
+//#endregion
 
+//#region GenerateDocumentResponse
 export class GenerateDocumentResponse {
   @ApiProperty({ description: 'Base64-encoded PDF document generated from the template.' })
   document!: string;
@@ -104,3 +110,4 @@ export class GenerateDocumentResponse {
   @ApiProperty({ description: 'Path on disk where the generated PDF has been saved.' })
   filePath!: string;
 }
+//#endregion

--- a/backend/generate/generate.service.ts
+++ b/backend/generate/generate.service.ts
@@ -2,6 +2,7 @@ import { Injectable, BadRequestException, Logger } from "@nestjs/common";
 import { DocumentGenerator } from "../../ContractGenerator";
 import { GenerateDocumentDto, GenerateDocumentResponse } from "./dto/generate-document.dto";
 import { DocumentConfig } from "../../interfaces/doc";
+import { DocumentParams, IPartiContratto } from "../../interfaces/content";
 import { readFileSync } from "fs";
 
 const DEFAULT_PATH_CONFIG = 'config.json';
@@ -9,48 +10,153 @@ const logger = new Logger('Generate');
 
 @Injectable()
 export class GenerateService {
-	private config: DocumentConfig;
-	constructor() {
-		// this.logger = new Logger('Generate Document - service');
-		const configFile = readFileSync(DEFAULT_PATH_CONFIG, 'utf-8');
-		this.config = JSON.parse(configFile);
-	}
+  private readonly defaultConfig: DocumentConfig;
 
-	async generateDocument(dto: GenerateDocumentDto)/*: Promise<sGenerateDocumentResponse> */ {
-		logger.log('start generateDocument')
-		logger.verbose(this.config);
-		if (!dto.fileName) {
-			throw new BadRequestException('file name is required to generate a document.');
-		}
+  constructor() {
+    this.defaultConfig = this.loadDefaultConfig();
+  }
 
-		// use exteranl config when present
-		if (dto.config) {
-			this.config = dto.config;
-		}
-		const configPages = Object(this.config['impostazioniPagina']);
+  async generateDocument(dto: GenerateDocumentDto): Promise<GenerateDocumentResponse> {
+    if (!dto.fileName || !dto.fileName.trim()) {
+      throw new BadRequestException('file name is required to generate a document.');
+    }
 
-		// check if there is a table in the params
-		if (dto.tableAnchor) {
-			// check the config.json to find the anchor, if not found throw error
-			console.log("Contenuti: ", configPages);
-		}
+    const fileName = this.ensurePdfExtension(dto.fileName.trim());
+    const generator = new DocumentGenerator();
+    const config = this.cloneConfig(dto.config ?? this.defaultConfig);
 
-		try {
-			const generator = new DocumentGenerator();
-			generator.setConfig(this.config);
+    try {
+      generator.setConfig(config);
 
+      const documentParams = this.buildDocumentParams(dto, config, fileName);
+      const document = await generator.generateDocument(documentParams);
 
-			//   const document = await generator.generateDocument(dto);
-			//   if (!document) {
-			//     throw new Error('Document generation failed.');
-			//   }
+      if (!document) {
+        throw new BadRequestException('Document generation failed.');
+      }
 
-			//   return {
-			//     document,
-			//     filePath: dto.fileName,
-			//   };
-		} catch (error) {
-			//   throw new BadRequestException(`Unable to generate document: ${error instanceof Error ? error.message : error}`);
-		}
-	}
+      return {
+        document,
+        filePath: fileName,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      const stack = error instanceof Error ? error.stack : undefined;
+      logger.error(`Unable to generate document: ${message}`, stack);
+      throw new BadRequestException(`Unable to generate document: ${message}`);
+    }
+  }
+
+  private loadDefaultConfig(): DocumentConfig {
+    try {
+      const configFile = readFileSync(DEFAULT_PATH_CONFIG, 'utf-8');
+      return JSON.parse(configFile) as DocumentConfig;
+    } catch (error) {
+      logger.error(`Failed to read default configuration from ${DEFAULT_PATH_CONFIG}`, error as Error);
+      throw new Error(`Unable to read configuration file ${DEFAULT_PATH_CONFIG}`);
+    }
+  }
+
+  private cloneConfig(config: DocumentConfig): DocumentConfig {
+    return JSON.parse(JSON.stringify(config)) as DocumentConfig;
+  }
+
+  private ensurePdfExtension(fileName: string): string {
+    return fileName.toLowerCase().endsWith('.pdf') ? fileName : `${fileName}.pdf`;
+  }
+
+  private buildDocumentParams(
+    dto: GenerateDocumentDto,
+    config: DocumentConfig,
+    fileName: string,
+  ): DocumentParams {
+    const params: DocumentParams = {
+      nomeFile: fileName,
+    };
+
+    const parti = this.buildParti(dto);
+    if (parti) {
+      params.parti = parti;
+    }
+
+    const numPagina = this.buildPageNumberConfig(dto);
+    if (numPagina) {
+      params.numPagina = numPagina;
+    }
+
+    const dynamicElements = this.buildDynamicElements(dto, config);
+    if (dynamicElements) {
+      params.dynamicElements = dynamicElements;
+    }
+
+    return params;
+  }
+
+  private buildParti(dto: GenerateDocumentDto): IPartiContratto | undefined {
+    const supplierProvided = dto.supplier || dto.pIvaCfSupplier || dto.supplierAddress;
+    const clientProvided = dto.client || dto.pIvaCfClient || dto.clientAddress;
+
+    if (!supplierProvided && !clientProvided) {
+      return undefined;
+    }
+
+    return {
+      fornitore: {
+        denominazione: dto.supplier ?? '',
+        codiceFiscale: dto.pIvaCfSupplier ?? '',
+        indirizzoCompleto: dto.supplierAddress ?? '',
+      },
+      cliente: {
+        denominazione: dto.client ?? '',
+        codiceFiscale: dto.pIvaCfClient ?? '',
+        indirizzoCompleto: dto.clientAddress ?? '',
+      },
+    };
+  }
+
+  private buildPageNumberConfig(dto: GenerateDocumentDto): DocumentParams['numPagina'] | undefined {
+    if (!dto.labelPagNum) {
+      return undefined;
+    }
+
+    return {
+      label: dto.labelPagNum,
+      fontId: dto.fontPagNum,
+      totPages: dto.totPagNum,
+    };
+  }
+
+  private buildDynamicElements(
+    dto: GenerateDocumentDto,
+    config: DocumentConfig,
+  ): DocumentParams['dynamicElements'] | undefined {
+    if (!dto.tableAnchor) {
+      return undefined;
+    }
+
+    if (!dto.tableBody || dto.tableBody.length === 0) {
+      throw new BadRequestException('tableBody is required when tableAnchor is provided.');
+    }
+
+    const tableConfig: any = {
+      body: dto.tableBody,
+    };
+
+    if (dto.tableHead && dto.tableHead.length > 0) {
+      tableConfig.head = [dto.tableHead];
+    }
+
+    if (config.tableStyle) {
+      tableConfig.styles = {
+        ...config.tableStyle,
+      };
+    }
+
+    return {
+      [dto.tableAnchor]: {
+        type: 'table',
+        config: tableConfig,
+      },
+    };
+  }
 }

--- a/backend/generate/generate.service.ts
+++ b/backend/generate/generate.service.ts
@@ -37,7 +37,7 @@ export class GenerateService {
 
       return {
         document,
-        filePath: fileName,
+        filePath: fileName
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES6",
     "module": "commonjs",
+    "moduleResolution": "node",
     "declaration": true,
     "removeComments": false,
     "outDir": "./dist",


### PR DESCRIPTION
## Summary
- load the default configuration once in the generation service and clone it for each request
- map the DTO payload to `DocumentParams`, including parties, pagination and table configuration, before invoking the generator
- expose the configuration schema in Swagger and ensure the TypeScript compiler resolves Node-style modules

## Testing
- `npm run build` *(fails: missing @nestjs packages in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dea45bd7e483309359594b2a1f9204